### PR TITLE
Refactor UV attribute in SharedStageBillboard and SharedStagePlaneMesh

### DIFF
--- a/__test__/SharedStageBillboard.spec.ts
+++ b/__test__/SharedStageBillboard.spec.ts
@@ -22,6 +22,12 @@ describe("SharedStageBillboard", () => {
     expect(billboard).toBeInstanceOf(Sprite);
   });
 
+  /**
+   * SharedStageBillboardはSpriteのデフォルトgeometryを使用せず、PlaneGeometryを使用している。
+   * UV座標の更新処理を共有化するため。
+   *
+   * SpriteとPlaneGeometryは、頂点のインデックスが異なる。
+   */
   it("should set correct position and uv attributes upon SharedStageBillboard creation", () => {
     const billboard = generateBillboard();
     const position = billboard.geometry.getAttribute("position");

--- a/__test__/SharedStageBillboard.spec.ts
+++ b/__test__/SharedStageBillboard.spec.ts
@@ -30,25 +30,19 @@ describe("SharedStageBillboard", () => {
    */
   it("should set correct position and uv attributes upon SharedStageBillboard creation", () => {
     const billboard = generateBillboard();
-    const position = billboard.geometry.getAttribute("position");
-    expect(position.getX(0)).toEqual(-0.5);
-    expect(position.getY(0)).toEqual(0.5);
-    expect(position.getX(1)).toEqual(0.5);
-    expect(position.getY(1)).toEqual(0.5);
-    expect(position.getX(2)).toEqual(-0.5);
-    expect(position.getY(2)).toEqual(-0.5);
-    expect(position.getX(3)).toEqual(0.5);
-    expect(position.getY(3)).toEqual(-0.5);
 
+    const position = billboard.geometry.getAttribute("position");
     const uv = billboard.geometry.getAttribute("uv");
-    expect(uv.getX(0)).toEqual(0);
-    expect(uv.getY(0)).toEqual(1);
-    expect(uv.getX(1)).toEqual(1);
-    expect(uv.getY(1)).toEqual(1);
-    expect(uv.getX(2)).toEqual(0);
-    expect(uv.getY(2)).toEqual(0);
-    expect(uv.getX(3)).toEqual(1);
-    expect(uv.getY(3)).toEqual(0);
+    const checkAttribute = (index: number, x: number, y: number) => {
+      expect(position.getX(index)).toEqual(x - 0.5);
+      expect(position.getY(index)).toEqual(y - 0.5);
+      expect(uv.getX(index)).toEqual(x);
+      expect(uv.getY(index)).toEqual(y);
+    };
+    checkAttribute(0, 0, 1);
+    checkAttribute(1, 1, 1);
+    checkAttribute(2, 0, 0);
+    checkAttribute(3, 1, 0);
   });
 
   it.fails(

--- a/__test__/SharedStageBillboard.spec.ts
+++ b/__test__/SharedStageBillboard.spec.ts
@@ -22,6 +22,29 @@ describe("SharedStageBillboard", () => {
     expect(billboard).toBeInstanceOf(Sprite);
   });
 
+  it("should set correct position and uv attributes upon SharedStageBillboard creation", () => {
+    const billboard = generateBillboard();
+    const position = billboard.geometry.getAttribute("position");
+    expect(position.getX(0)).toEqual(-0.5);
+    expect(position.getY(0)).toEqual(0.5);
+    expect(position.getX(1)).toEqual(0.5);
+    expect(position.getY(1)).toEqual(0.5);
+    expect(position.getX(2)).toEqual(-0.5);
+    expect(position.getY(2)).toEqual(-0.5);
+    expect(position.getX(3)).toEqual(0.5);
+    expect(position.getY(3)).toEqual(-0.5);
+
+    const uv = billboard.geometry.getAttribute("uv");
+    expect(uv.getX(0)).toEqual(0);
+    expect(uv.getY(0)).toEqual(1);
+    expect(uv.getX(1)).toEqual(1);
+    expect(uv.getY(1)).toEqual(1);
+    expect(uv.getX(2)).toEqual(0);
+    expect(uv.getY(2)).toEqual(0);
+    expect(uv.getX(3)).toEqual(1);
+    expect(uv.getY(3)).toEqual(0);
+  });
+
   it.fails(
     "should throw an error when to create a SharedStageBillboard without SharedStageTexture",
     () => {

--- a/__test__/SharedStageObject3D.ts
+++ b/__test__/SharedStageObject3D.ts
@@ -1,6 +1,5 @@
 import { SharedStageBillboard, SharedStagePlaneMesh } from "src";
-import { MeshBasicMaterial } from "three";
-import { expect, it } from "vitest";
+import { expect } from "vitest";
 
 export const textureArea = {
   x: 0,

--- a/src/SharedStageBillboard.ts
+++ b/src/SharedStageBillboard.ts
@@ -1,5 +1,9 @@
-import { Sprite, SpriteMaterial } from "three";
-import { TextureArea, isSharedStageMaterial } from "./index.js";
+import { PlaneGeometry, Sprite, SpriteMaterial } from "three";
+import {
+  TextureArea,
+  isSharedStageMaterial,
+  updateUVAttribute,
+} from "./index.js";
 
 export class SharedStageBillboard extends Sprite {
   get imageScale() {
@@ -44,8 +48,10 @@ export class SharedStageBillboard extends Sprite {
     /**
      * SharedStageBillboardでは、Sprite間でジオメトリを共有しない。
      * 個別にUV座標を持つため。
+     * また、PlaneとpositionおよびUVを共通化するためPlaneGeometryを使用する。
      */
-    this.geometry = this.geometry.clone();
+    this.geometry = new PlaneGeometry();
+
     this.material = sharedMaterial;
     this.updateScale();
     this.updateUVAttribute();
@@ -66,15 +72,6 @@ export class SharedStageBillboard extends Sprite {
    * ジオメトリにUV座標を設定する。
    */
   private updateUVAttribute(): void {
-    if (!isSharedStageMaterial(this.sharedMaterial)) {
-      throw new Error("sharedMaterial.map must be SharedStageTexture");
-    }
-    const area = this.sharedMaterial.map.calcurateUV(this._textureArea);
-    const uv = this.geometry.getAttribute("uv");
-    uv.setXY(0, area.x1, area.y1);
-    uv.setXY(1, area.x2, area.y1);
-    uv.setXY(2, area.x2, area.y2);
-    uv.setXY(3, area.x1, area.y2);
-    uv.needsUpdate = true;
+    updateUVAttribute(this.geometry, this.sharedMaterial, this._textureArea);
   }
 }

--- a/src/SharedStagePlaneMesh.ts
+++ b/src/SharedStagePlaneMesh.ts
@@ -1,6 +1,10 @@
 import { Material, Mesh, PlaneGeometry } from "three";
 import { CameraChaser } from "./CameraChaser.js";
-import { isSharedStageMaterial, TextureArea } from "./SharedStageTexture.js";
+import {
+  isSharedStageMaterial,
+  TextureArea,
+  updateUVAttribute,
+} from "./SharedStageTexture.js";
 
 /**
  * Canvasに描画可能な板オブジェクト。
@@ -61,15 +65,6 @@ export class SharedStagePlaneMesh extends Mesh {
    * ジオメトリにUV座標を設定する。
    */
   private updateUVAttribute(): void {
-    if (!isSharedStageMaterial(this.sharedMaterial)) {
-      throw new Error("sharedMaterial.map must be SharedStageTexture");
-    }
-    const area = this.sharedMaterial.map.calcurateUV(this._textureArea);
-    const uv = this.geometry.getAttribute("uv");
-    uv.setXY(0, area.x1, area.y2);
-    uv.setXY(1, area.x2, area.y2);
-    uv.setXY(2, area.x1, area.y1);
-    uv.setXY(3, area.x2, area.y1);
-    uv.needsUpdate = true;
+    updateUVAttribute(this.geometry, this.sharedMaterial, this._textureArea);
   }
 }

--- a/src/SharedStagePlaneMesh.ts
+++ b/src/SharedStagePlaneMesh.ts
@@ -41,7 +41,6 @@ export class SharedStagePlaneMesh extends Mesh {
       prevTextureArea.width !== value.width ||
       prevTextureArea.height !== value.height
     ) {
-      //TODO : ジオメトリの再生性ではなく、positionアトリビュートの更新で対応可能か検討する。
       this.geometry = new PlaneGeometry(value.width, value.height);
     }
     this.updateUVAttribute();

--- a/src/SharedStageTexture.ts
+++ b/src/SharedStageTexture.ts
@@ -1,5 +1,5 @@
 import { Application, Container, Ticker } from "pixi.js";
-import { Texture } from "three";
+import { BufferGeometry, Material, Texture } from "three";
 
 /**
  * Billboard用の共有テクスチャ
@@ -79,6 +79,27 @@ export const isSharedStageMaterial = (
 ): material is ISharedStageMaterial => {
   return "map" in material && material.map instanceof SharedStageTexture;
 };
+
+/**
+ * ジオメトリにUV座標を設定する。
+ */
+export const updateUVAttribute = (
+  geometry: BufferGeometry,
+  material: Material,
+  textureArea: TextureArea,
+): void => {
+  if (!isSharedStageMaterial(material)) {
+    throw new Error("sharedMaterial.map must be SharedStageTexture");
+  }
+  const area = material.map.calcurateUV(textureArea);
+  const uv = geometry.getAttribute("uv");
+  uv.setXY(0, area.x1, area.y2);
+  uv.setXY(1, area.x2, area.y2);
+  uv.setXY(2, area.x1, area.y1);
+  uv.setXY(3, area.x2, area.y1);
+  uv.needsUpdate = true;
+};
+
 /**
  * テクスチャからどの領域を表示するのかを表すインターフェース
  */


### PR DESCRIPTION
This pull request refactors the UV attribute in the SharedStageBillboard and SharedStagePlaneMesh classes. It updates the UV attribute setting process to use a shared function, `updateUVAttribute`, which sets the UV coordinates for the geometry. This improves code readability and maintainability.