### PR TITLE
Remove biome-ignore comments for explicit any usage

### DIFF
--- a/__test__/PixiMultiViewManager.spec.ts
+++ b/__test__/PixiMultiViewManager.spec.ts
@@ -22,7 +22,6 @@ import type { IRenderablePixiView } from "../src/RenderablePixiView";
 const getRenderQueue = (
   manager: PixiMultiViewManager,
 ): Set<IRenderablePixiView> => {
-  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
   return (manager as any)._renderQueue;
 };
 
@@ -32,7 +31,6 @@ const getRenderQueue = (
  * @returns The Ticker instance.
  */
 const getTicker = (manager: PixiMultiViewManager): Ticker => {
-  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
   return (manager as any)._ticker;
 };
 
@@ -42,7 +40,6 @@ const getTicker = (manager: PixiMultiViewManager): Ticker => {
  * @returns The render loop function.
  */
 const getRenderLoop = (manager: PixiMultiViewManager): (() => void) => {
-  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
   return (manager as any)._renderLoop;
 };
 


### PR DESCRIPTION
Eliminate unnecessary biome-ignore comments related to explicit any usage in the code. This improves code clarity and adheres to linting standards.