### PR TITLE
chore : Remove unnecessary write flag from biome check in pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,3 @@
-biome check --write --organize-imports-enabled=false --no-errors-on-unmatched
+biome check --organize-imports-enabled=false --no-errors-on-unmatched
 
 npx vitest --run


### PR DESCRIPTION
Eliminate the redundant write flag in the biome check to streamline the pre-push hook process.