### PR TITLE
docs: improve unit test descriptions for better clarity and readability

### DIFF
--- a/__test__/BillBoardController.spec.ts
+++ b/__test__/BillBoardController.spec.ts
@@ -20,17 +20,17 @@ describe("BillBoardController", () => {
     return controller;
   };
 
-  test("constructor : Mesh", async () => {
+  test("should successfully create BillBoardController with Mesh target and load texture from URL", async () => {
     const controller = testBillBoardController(textureURL, new Mesh());
     await expect(controller.textureLoaderPromise).resolves.toBeUndefined();
   });
 
-  test("constructor : Sprite", async () => {
+  test("should successfully create BillBoardController with Sprite target and load texture from URL", async () => {
     const controller = testBillBoardController(textureURL, new Sprite());
     await expect(controller.textureLoaderPromise).resolves.toBeUndefined();
   });
 
-  test("constructor : error", async () => {
+  test("should handle texture loading errors gracefully when provided invalid URL", async () => {
     const mockError = vi.spyOn(console, "error").mockImplementation((x) => x);
 
     const controller = testBillBoardController("not exist url", new Mesh());

--- a/__test__/BillBoardObject3D.ts
+++ b/__test__/BillBoardObject3D.ts
@@ -2,7 +2,7 @@ import type { BillBoard, BillBoardPlane } from "../src/index.js";
 import { expect, test } from "vitest";
 
 export const billboardCommonTest = (target: BillBoard | BillBoardPlane) => {
-  test("change image scale", () => {
+  test("should update imageScale property and maintain correct scaling behavior", () => {
     expect(target).not.toBeUndefined();
     expect(target.imageScale).toBe(1);
 

--- a/__test__/BillBoardOptions.spec.ts
+++ b/__test__/BillBoardOptions.spec.ts
@@ -3,7 +3,7 @@ import { LinearFilter } from "three";
 import { describe, expect, test } from "vitest";
 
 describe("BillBoardOptions", () => {
-  test("init", () => {
+  test("should initialize default BillBoard options with LinearFilter for lightweight performance", () => {
     const options = BillBoardOptionUtil.init(undefined);
     expect(options.minFilter).toBe(LinearFilter);
   });

--- a/__test__/CameraChaser.spec.ts
+++ b/__test__/CameraChaser.spec.ts
@@ -3,14 +3,14 @@ import { Object3D, PerspectiveCamera, Vector3 } from "three";
 import { describe, expect, test } from "vitest";
 
 describe("CameraChaser", () => {
-  test("constructor", () => {
+  test("should initialize CameraChaser and set up onBeforeRender callback for camera tracking", () => {
     const target = new Object3D();
     const cameraChaser = new CameraChaser(target);
     expect(cameraChaser).not.toBeUndefined();
     expect(target.onBeforeRender).not.toBeUndefined();
   });
 
-  test("lookCamera", () => {
+  test("should correctly rotate object to face camera horizontally", () => {
     const camera = new PerspectiveCamera(45, 1, 1, 1000);
 
     const target = new Object3D();

--- a/__test__/MultiViewPixiBillboard.spec.ts
+++ b/__test__/MultiViewPixiBillboard.spec.ts
@@ -83,7 +83,7 @@ describe("MultiViewPixiBillboard", () => {
     vi.restoreAllMocks();
   });
 
-  it("should be created with correct initial properties", () => {
+  it("should initialize with correct initial properties", () => {
     expect(billboard).toBeInstanceOf(MultiViewPixiBillboard);
     expect(billboard.material).toBeInstanceOf(SpriteMaterial);
     expect(billboard.canvas).toBeInstanceOf(HTMLCanvasElement);
@@ -99,7 +99,7 @@ describe("MultiViewPixiBillboard", () => {
     expect(requestRenderSpy).toHaveBeenCalledWith(billboard);
   });
 
-  it("setScale should set the scale of the sprite", () => {
+  it("should update sprite scale when setScale is called", () => {
     const scale = 0.1;
     billboard.setScale(scale);
     expect(billboard.scale.x).toBe(scale * width);
@@ -109,7 +109,7 @@ describe("MultiViewPixiBillboard", () => {
     expect(requestRenderSpy).toHaveBeenCalledTimes(2); // 初期化時とsetScaleで2回呼ばれる
   });
 
-  it("setScale should not set scale if disposed", () => {
+  it("should not update scale when disposed", () => {
     billboard.dispose();
     requestRenderSpy.mockClear(); // dispose後のrequestRender呼び出しをクリア
     consoleWarnSpy.mockClear(); // dispose後のconsole.warn呼び出しをクリア

--- a/__test__/MultiViewPixiPlaneMesh.spec.ts
+++ b/__test__/MultiViewPixiPlaneMesh.spec.ts
@@ -91,7 +91,7 @@ describe("MultiViewPixiPlaneMesh", () => {
     vi.restoreAllMocks();
   });
 
-  it("should be created with correct initial properties", () => {
+  it("should initialize with correct initial properties", () => {
     expect(planeMesh).toBeInstanceOf(MultiViewPixiPlaneMesh);
     expect(planeMesh.geometry).toBeInstanceOf(PlaneGeometry);
     expect(planeMesh.material).toBeInstanceOf(MeshBasicMaterial);

--- a/__test__/PixiMultiViewManager.spec.ts
+++ b/__test__/PixiMultiViewManager.spec.ts
@@ -148,7 +148,7 @@ describe("PixiMultiViewManager", () => {
     vi.restoreAllMocks();
   });
 
-  it("should be created with a Ticker instance", () => {
+  it("should initialize with provided Ticker instance", () => {
     expect(manager).toBeInstanceOf(PixiMultiViewManager);
     expect(getTicker(manager)).toBe(ticker);
   });

--- a/__test__/ScaleCalculator.spec.ts
+++ b/__test__/ScaleCalculator.spec.ts
@@ -3,7 +3,7 @@ import { PerspectiveCamera } from "three";
 import { describe, expect, test } from "vitest";
 
 describe("ScaleCalculator", () => {
-  test("get scale", () => {
+  test("should calculate correct non-attenuation scale for pixel-perfect rendering at given camera distance", () => {
     const H = 480;
     const W = 640;
     const camera = new PerspectiveCamera(45, W / H, 1, 400);

--- a/__test__/SharedStageBillboard.spec.ts
+++ b/__test__/SharedStageBillboard.spec.ts
@@ -44,7 +44,7 @@ describe("SharedStageBillboard", () => {
   });
 
   it.fails(
-    "should throw an error when to create a SharedStageBillboard without SharedStageTexture",
+    "should throw an error when creating SharedStageBillboard without SharedStageTexture",
     () => {
       const material = new SpriteMaterial();
       new SharedStageBillboard(material, textureArea);
@@ -52,7 +52,7 @@ describe("SharedStageBillboard", () => {
   );
 
   it.fails(
-    "should throw an error when updating texture area with a material that has not a map of SharedStageTexture",
+    "should throw an error when updating texture area with material that does not have SharedStageTexture map",
     async () => {
       const billboard = await generateBillboard();
       billboard.sharedMaterial = new SpriteMaterial();

--- a/__test__/SharedStageBillboard.spec.ts
+++ b/__test__/SharedStageBillboard.spec.ts
@@ -15,7 +15,7 @@ describe("SharedStageBillboard", () => {
     return billboard;
   };
 
-  it("should be able to create a SharedStageBillboard", async () => {
+  it("should create SharedStageBillboard instance successfully", async () => {
     const billboard = await generateBillboard();
     expect(billboard).toBeInstanceOf(Sprite);
   });
@@ -60,12 +60,12 @@ describe("SharedStageBillboard", () => {
     },
   );
 
-  it("should be able to update texture area", async () => {
+  it("should correctly update UV coordinates when texture area changes on shared canvas", async () => {
     const billboard = await generateBillboard();
     testUpdateTextureAreaAndUV(billboard);
   });
 
-  it("should be able to update image scale", async () => {
+  it("should scale billboard dimensions proportionally when imageScale property changes", async () => {
     const billboard = await generateBillboard();
 
     const scale = 2.0;

--- a/__test__/SharedStagePlaneMesh.spec.ts
+++ b/__test__/SharedStagePlaneMesh.spec.ts
@@ -21,7 +21,7 @@ describe("SharedStagePlaneMesh", () => {
   });
 
   it.fails(
-    "should throw an error when to create a SharedStagePlaneMesh without SharedStageTexture",
+    "should throw an error when creating SharedStagePlaneMesh without SharedStageTexture",
     () => {
       const material = new MeshBasicMaterial();
       new SharedStagePlaneMesh(material, textureArea);
@@ -29,7 +29,7 @@ describe("SharedStagePlaneMesh", () => {
   );
 
   it.fails(
-    "should throw an error when updating texture area with a material that has not a map of SharedStageTexture",
+    "should throw an error when updating texture area with material that does not have SharedStageTexture map",
     async () => {
       const plane = await generateSharedStagePlaneMesh();
       plane.sharedMaterial = new MeshBasicMaterial();

--- a/__test__/SharedStagePlaneMesh.spec.ts
+++ b/__test__/SharedStagePlaneMesh.spec.ts
@@ -15,7 +15,7 @@ describe("SharedStagePlaneMesh", () => {
     return plane;
   };
 
-  it("should be able to create a SharedStagePlaneMesh", async () => {
+  it("should create SharedStagePlaneMesh instance successfully", async () => {
     const plane = await generateSharedStagePlaneMesh();
     expect(plane).toBeInstanceOf(SharedStagePlaneMesh);
   });
@@ -37,7 +37,7 @@ describe("SharedStagePlaneMesh", () => {
     },
   );
 
-  it("should be able to update texture area and uv", async () => {
+  it("should correctly update UV coordinates when texture area changes", async () => {
     const plane = await generateSharedStagePlaneMesh();
     testUpdateTextureAreaAndUV(plane);
   });

--- a/__test__/SharedStageTexture.spec.ts
+++ b/__test__/SharedStageTexture.spec.ts
@@ -3,7 +3,7 @@ import { SharedStageTexture } from "../src/index.js";
 import { Graphics, Ticker } from "pixi.js";
 
 describe("SharedStageTexture", () => {
-  it("should create an instance of SharedStageTexture with correct dimensions", async () => {
+  it("should initialize with correct dimensions", async () => {
     const texture = new SharedStageTexture();
     await texture.init(256, 128);
 
@@ -14,7 +14,7 @@ describe("SharedStageTexture", () => {
     expect(texture.image).toBeTruthy();
   });
 
-  it("should correctly drawable Canvas pixels using SharedStageTexture", async () => {
+  it("should render Canvas pixels correctly using SharedStageTexture", async () => {
     const w = 32;
     const h = 32;
     const texture = new SharedStageTexture();


### PR DESCRIPTION
## Summary
• Fixed grammatical errors in test descriptions (e.g., "correctly drawable" → "render correctly")
• Removed redundant phrases to improve conciseness and readability
• Enhanced clarity by replacing vague terms like "be created" with more specific "initialize"
• Corrected English grammar issues in multiple test files for consistency

## Test plan
- [x] All 106 tests continue to pass
- [x] Build process completes successfully
- [x] TypeDoc documentation generates without errors
- [x] Code formatting and linting pass

🤖 Generated with [Claude Code](https://claude.ai/code)