### PR TITLE
fix: modify pre-push hook to only check changed files against main branch

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 set -e
 
-npx biome ci .
+npx biome ci --changed --no-errors-on-unmatched .
 npx vitest --run


### PR DESCRIPTION
## Summary
- Modified pre-push hook to use `--changed` flag to only check files that have changed compared to main branch
- Added `--no-errors-on-unmatched` flag to prevent errors when no files need checking
- Resolves issue where unstaged files with biome errors were causing pre-push failures

## Changes
- Updated `.husky/pre-push` to use `npx biome ci --changed --no-errors-on-unmatched .`
- This ensures only staged/committed changes are checked, not unstaged working directory files

## Test plan
- [x] Verified pre-push hook passes when no files are changed
- [x] Verified pre-push hook only checks files that have actually changed from main branch
- [x] Verified unstaged files with biome errors no longer cause pre-push failures
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pre-push checks to run code analysis only on changed files, making the process faster and more efficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->