### PR TITLE
Relax dependabot auto-merge criteria for better automation

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,7 +19,21 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
-        if: steps.metadata.outputs.dependency-type == 'direct:development' && steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        if: |
+          (
+            steps.metadata.outputs.dependency-type == 'direct:development' && 
+            steps.metadata.outputs.update-type == 'version-update:semver-patch'
+          ) || (
+            steps.metadata.outputs.dependency-type == 'direct:production' && 
+            steps.metadata.outputs.update-type == 'version-update:semver-patch'
+          ) || (
+            steps.metadata.outputs.dependency-type == 'indirect' && 
+            steps.metadata.outputs.update-type == 'version-update:semver-patch'
+          ) || (
+            steps.metadata.outputs.dependency-type == 'direct:development' && 
+            steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
+            startsWith(steps.metadata.outputs.previous-version, '0.') == false
+          )
         run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,17 +21,18 @@ jobs:
       - name: Enable auto-merge for Dependabot PRs
         if: |
           (
-            steps.metadata.outputs.dependency-type == 'direct:development' && 
+            steps.metadata.outputs.dependency-type == 'direct:development' &&
             steps.metadata.outputs.update-type == 'version-update:semver-patch'
           ) || (
-            steps.metadata.outputs.dependency-type == 'direct:production' && 
+            steps.metadata.outputs.dependency-type == 'direct:production' &&
             steps.metadata.outputs.update-type == 'version-update:semver-patch'
           ) || (
-            steps.metadata.outputs.dependency-type == 'indirect' && 
+            steps.metadata.outputs.dependency-type == 'indirect' &&
             steps.metadata.outputs.update-type == 'version-update:semver-patch'
           ) || (
-            steps.metadata.outputs.dependency-type == 'direct:development' && 
+            steps.metadata.outputs.dependency-type == 'direct:development' &&
             steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
+            steps.metadata.outputs.previous-version != '' &&
             startsWith(steps.metadata.outputs.previous-version, '0.') == false
           )
         run: gh pr merge --auto --rebase "$PR_URL"


### PR DESCRIPTION
## Summary
- Expand dependabot auto-merge criteria to include more safe dependency updates
- Enable better automation while maintaining safety through comprehensive testing

## Changes
- ✅ **Production dependencies**: Auto-merge patch updates
- ✅ **Indirect dependencies**: Auto-merge patch updates  
- ✅ **Development dependencies**: Auto-merge minor updates (excluding v0.x versions)
- ✅ **Development dependencies**: Continue auto-merge patch updates (existing)

## Auto-merge Conditions
The workflow now auto-merges PRs when any of these conditions are met:

1. `direct:development` + `semver-patch` (existing behavior)
2. `direct:production` + `semver-patch` (new)
3. `indirect` + `semver-patch` (new)
4. `direct:development` + `semver-minor` + non-v0.x versions (new)

## Safety Measures
- **Comprehensive test suite**: 130 tests provide thorough coverage
- **CI validation**: All updates must pass CI checks before auto-merge
- **Version filtering**: Excludes potentially breaking v0.x minor updates
- **Rebase strategy**: Uses `--rebase` to maintain clean history

## Benefits
- Reduced manual intervention for routine dependency updates
- Faster security patch adoption
- Improved project maintenance automation
- Lower maintenance overhead while preserving safety

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded automatic merging for dependency updates to reduce manual intervention.
  * Now auto-merges patch updates for development, production, and indirect dependencies.
  * Enables selective minor updates for development dependencies when deemed safe.
  * Adds extra validation to ensure minor updates are only auto-merged when the prior version is valid/non-zero.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->