### PR TITLE
fix: add ANGLE SwiftShader flags for Chrome 144+ WebGL in CI

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,11 @@ export default defineConfig({
       instances: [
         {
           browser: "chrome",
+          capabilities: {
+            "goog:chromeOptions": {
+              args: ["--use-gl=angle", "--use-angle=swiftshader"],
+            },
+          },
         },
       ],
     },


### PR DESCRIPTION
## Summary

Closes #504

## Scope

**Changes:**
- Add `--use-gl=angle` and `--use-angle=swiftshader` Chrome flags to `vitest.config.ts`

**Unchanged:**
- Test files, source code, and other configuration

## Test Plan

- Local `npm test`: 18 test files, 130 tests all pass
- CI workflow should pass with the new Chrome flags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced Chrome browser configuration to improve test rendering compatibility and reliability during automated test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->