### PR TITLE
docs: add Chrome shared memory sizing reference skill

### DIFF
--- a/.claude/skills/chrome-shm-sizing/SKILL.md
+++ b/.claude/skills/chrome-shm-sizing/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: chrome-shm-sizing
+description: Chrome shared memory sizing reference for DevContainer. Use when adjusting --shm-size, debugging Chrome crashes in containers, or reviewing browser test infrastructure.
+allowed-tools: Read
+---
+
+# Chrome Shared Memory Sizing
+
+Reference for `--shm-size` configuration in this project's DevContainer environments.
+
+---
+
+## Current Configuration
+
+| Parameter | Value |
+|-----------|-------|
+| `--shm-size` | `2g` |
+| Verified minimum | `1g` (all tests pass) |
+| Safety margin | 2x |
+
+### Configuration Locations
+
+- `.devcontainer/devcontainer.json` - npm Runner container
+- `.devcontainer/claude/devcontainer.json` - Claude Code Sandbox container
+
+---
+
+## Sizing Rationale
+
+- **1GB**: Sufficient for the full test suite as of 2026-02-24 (commit `a524153`)
+- **2GB**: Chosen to provide 2x margin for future test suite growth
+
+---
+
+## Background
+
+Chrome uses `/dev/shm` (shared memory) for inter-process communication between browser and renderer processes. Docker containers default to 64MB for `/dev/shm`, which is insufficient for Chrome and causes:
+
+- Tab crashes (`SIGBUS` errors)
+- Renderer process termination
+- Flaky test failures
+
+---
+
+## Review Triggers
+
+Re-evaluate the sizing when:
+
+- Browser tests become flaky with memory-related errors
+- Test suite grows significantly (e.g., adding many screenshot tests)
+- Chrome major version upgrades change memory requirements
+
+---
+
+**Baseline**: 2026-02-24 / `a524153`


### PR DESCRIPTION
## Summary

Add a project-specific Claude Code reference skill documenting the `--shm-size=2g` configuration and its rationale for DevContainer environments.

**Scope:**

**Changes:**
- Add `.claude/skills/chrome-shm-sizing/SKILL.md` with sizing baseline, rationale, and review triggers

**Unchanged:**
- DevContainer configuration files (already set to 2g)

## Test plan

- [x] Pre-push CI checks passed (biome ci + vitest 130 tests)
- [ ] Verify skill is discoverable via `/chrome-shm-sizing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation on Chrome shared memory sizing for DevContainer environments, including configuration recommendations, sizing rationale, and background on Chrome's shared memory usage in containerized development setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->