### PR TITLE
docs: update README badges and add DevContainer commands to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,17 +4,39 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Development Commands
 
-### Build and Test
-- `npm run build` - Build TypeScript and generate demo pages
-- `npm run buildTS` - Compile TypeScript to ESM in ./esm directory
-- `npm test` - Run tests with Vitest
-- `npm run test:watch` - Run tests in watch mode
-- `npm run coverage` - Run tests with coverage reporting
+**IMPORTANT**: All npm/npx commands MUST be executed via DevContainer. Do NOT run npm or npx directly on the host. The DevContainer (`.devcontainer/devcontainer.json`) provides Node 22, Chrome, and xvfb required for testing.
 
-### Development Server
-- `npm run start:dev` - Start development server with file watching
-- `npm run server` - Start browser-sync server for demo pages
-- `npm run demo` - Generate demo pages using gulptask-demo-page
+```bash
+# Start DevContainer (if not running)
+devcontainer up --workspace-folder .
+
+# Build TypeScript and generate demo pages
+devcontainer exec --workspace-folder . npm run build
+
+# Compile TypeScript to ESM in ./esm directory
+devcontainer exec --workspace-folder . npm run buildTS
+
+# Run tests with Vitest
+devcontainer exec --workspace-folder . npm test
+
+# Run tests in watch mode
+devcontainer exec --workspace-folder . npm run test:watch
+
+# Run tests with coverage reporting
+devcontainer exec --workspace-folder . npm run coverage
+
+# Start development server with file watching
+devcontainer exec --workspace-folder . npm run start:dev
+
+# Start browser-sync server for demo pages
+devcontainer exec --workspace-folder . npm run server
+
+# Generate demo pages
+devcontainer exec --workspace-folder . npm run demo
+
+# Lint and format code
+devcontainer exec --workspace-folder . npx biome check --write
+```
 
 ### Demo Page Generation
 The `npm run demo` command automatically scans `demoSrc/` directory for JavaScript files with `demo_` prefix and generates corresponding HTML files in `docs/demo/`. Key points:
@@ -24,7 +46,7 @@ The `npm run demo` command automatically scans `demoSrc/` directory for JavaScri
 - Never manually edit files in `docs/` directory - modify source files in `demoSrc/` instead
 
 ### Code Quality
-- `biome check --write` - Lint and format code (configured in biome.json)
+- DevContainer-based Git hooks for pre-commit (Biome format) and pre-push (Biome CI + tests)
 - Files are automatically formatted on commit via lint-staged
 
 ## Project Architecture

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 > Billboard module for three.js with multiple rendering approaches
 
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
-
-[![ReadMe Card](https://github-readme-stats.vercel.app/api/pin/?username=MasatoMakino&repo=threejs-billboard&show_owner=true)](https://github.com/MasatoMakino/threejs-billboard)
+[![npm version](https://img.shields.io/npm/v/@masatomakino/threejs-billboard.svg?style=flat)](https://www.npmjs.com/package/@masatomakino/threejs-billboard)
+[![GitHub](https://img.shields.io/badge/GitHub-Repository-blue?logo=github&style=flat)](https://github.com/MasatoMakino/threejs-billboard)
 
 ## Demo
 


### PR DESCRIPTION
## Summary

- Replace unreliable GitHub Readme Stats card (vercel.app) with npm version and GitHub Repository badges
- Update CLAUDE.md Development Commands section with DevContainer-prefixed commands

**Changes:**
- README.md: Badge section updated (3 consecutive badges: MIT License, npm version, GitHub)
- CLAUDE.md: All npm/npx commands now use `devcontainer exec` prefix, added IMPORTANT note about DevContainer requirement, updated Code Quality section

**Unchanged:**
- Demo Page Generation subsection content
- All other CLAUDE.md sections (Architecture, Rules, etc.)
- README.md content beyond badge section

## Test Plan

- [ ] Verify README badges render correctly on GitHub PR preview
- [ ] Confirm npm badge links to https://www.npmjs.com/package/@masatomakino/threejs-billboard
- [ ] Confirm GitHub badge links to https://github.com/MasatoMakino/threejs-billboard
- [ ] Verify CLAUDE.md commands are copy-pasteable and executable with DevContainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository badges in README with npm version and GitHub repository information.

* **Chores**
  * Updated development workflow and setup documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->